### PR TITLE
Use <legend> instead of <h4> in fieldset

### DIFF
--- a/src/renderFieldset.js
+++ b/src/renderFieldset.js
@@ -16,7 +16,7 @@ function getClassName(locals) {
 }
 
 export default function renderFieldset(children, locals) {
-  const legend = locals.label ? <h4 className="ui dividing header">{locals.label}</h4> : null
+  const legend = locals.label ? <legend className="ui dividing header">{locals.label}</legend> : null
   const style = locals.path.length === 0 ? {
     border: 0,
     margin: 0,


### PR DESCRIPTION
Legend has more semantic to fieldset than heading. Also, it forces to use `h4`, sometimes we might need `h2` or `h3`.
